### PR TITLE
ci + f3 backports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+cache: cargo
+dist: trusty
+language: rust
+# NOTE This is default but can be override on a target by target basis in the "matrix" below
+rust: nightly
+services: docker
+sudo: required
+
+env:
+  global:
+    - TARGET=thumbv7m-none-eabi
+
+matrix:
+  include:
+    # FIXME(rust-lang/rust#38406) uncomment this when rust-lang/rust#38411
+    # reaches nightly
+    # - env: TARGET=thumbv6m-none-eabi
+    - env: TARGET=thumbv7em-none-eabi
+    - env: TARGET=thumbv7em-none-eabihf
+
+install:
+  - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TRAVIS_RUST_VERSION
+  - source ~/.cargo/env
+  - rustup component add rust-src
+
+script:
+  - cargo generate-lockfile
+  - if [[ $TRAVIS_OS_NAME = linux ]]; then
+      sh ci/run-docker.sh $TARGET || exit 1;
+    else
+      sh ci/run.sh || exit 1;
+    fi;
+  # Travis can't cache files that are not readable by "others"
+  - chmod -R a+r $HOME/.cargo
+
+branches:
+  only:
+    - auto
+    - try

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ version = "0.1.0"
 cortex-m = "0.1.4"
 r0 = "0.1.0"
 
-[dependencies.compiler-builtins-snapshot]
-features = ["memcpy"]
-version = "0.0.20161008"
+[dependencies.compiler_builtins]
+features = ["mem"]
+git = "https://github.com/rust-lang-nursery/compiler-builtins"
 
 [profile.release]
 lto = true

--- a/ci/docker/thumbv6m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv6m-none-eabi/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gcc \
+    gcc-arm-none-eabi \
+    libc6-dev \
+    libnewlib-dev
+RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
+    sh -s -- --git japaric/xargo --tag v0.2.3 --target x86_64-unknown-linux-gnu --to /usr/bin

--- a/ci/docker/thumbv7em-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabi/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gcc \
+    gcc-arm-none-eabi \
+    libc6-dev \
+    libnewlib-dev
+RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
+    sh -s -- --git japaric/xargo --tag v0.2.3 --target x86_64-unknown-linux-gnu --to /usr/bin

--- a/ci/docker/thumbv7em-none-eabihf/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabihf/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gcc \
+    gcc-arm-none-eabi \
+    libc6-dev \
+    libnewlib-dev
+RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
+    sh -s -- --git japaric/xargo --tag v0.2.3 --target x86_64-unknown-linux-gnu --to /usr/bin

--- a/ci/docker/thumbv7m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7m-none-eabi/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gcc \
+    gcc-arm-none-eabi \
+    libc6-dev \
+    libnewlib-dev
+RUN curl -LSfs https://japaric.github.io/trust/install.sh | \
+    sh -s -- --git japaric/xargo --tag v0.2.3 --target x86_64-unknown-linux-gnu --to /usr/bin

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -1,0 +1,35 @@
+set -ex
+
+run() {
+    # This directory needs to exist before calling docker, otherwise docker will create it but it
+    # will be owned by root
+    mkdir -p target
+
+    docker build -t $1 ci/docker/$1
+    docker run \
+           --rm \
+           --user $(id -u):$(id -g) \
+           -e CARGO_HOME=/cargo \
+           -e CARGO_TARGET_DIR=/target \
+           -e DEPLOY_VERSION=$DEPLOY_VERSION \
+           -e TARGET=$1 \
+           -e TRAVIS_OS_NAME=linux \
+           -e TRAVIS_RUST_VERSION=$TRAVIS_RUST_VERSION \
+           -e TRAVIS_TAG=$TRAVIS_TAG \
+           -e USER=$USER \
+           -v $HOME/.cargo:/cargo \
+           -v `pwd`/target:/target \
+           -v `pwd`:/checkout:ro \
+           -v `rustc --print sysroot`:/rust:ro \
+           -w /checkout \
+           -it $1 \
+           sh -c "HOME=/tmp PATH=\$PATH:/rust/bin ci/run.sh"
+}
+
+if [ -z $1 ]; then
+    for d in `ls ci/docker/`; do
+        run $d
+    done
+else
+    run $1
+fi

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,0 +1,16 @@
+set -ex
+
+run() {
+    case $TARGET in
+        thumbv*-none-eabi*)
+            xargo build --target $TARGET --example app
+            xargo build --target $TARGET --release --example app
+            ;;
+        *)
+            cargo build --target $TARGET
+            cargo build --target $TARGET --release
+            ;;
+    esac
+}
+
+run

--- a/memory.x
+++ b/memory.x
@@ -1,8 +1,8 @@
 MEMORY
 {
   /* TODO You must correct these values */
-  FLASH : ORIGIN = 0xBAAAAAAD, LENGTH = 0
-  RAM : ORIGIN = 0xBAAAAAAD, LENGTH = 0
+  FLASH : ORIGIN = 0x0BAAAD00, LENGTH = 2K
+  RAM : ORIGIN = 0x2BAAAD00, LENGTH = 0
 }
 
 ENTRY(_reset)

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,37 +1,33 @@
 //! Exceptions
-//!
-//!
-//!
-//!
-//!
 
 use cortex_m::{Handler, StackFrame};
 
 // This default exception handler gives you access to the previous stack frame
 // which is where the exception occurred. To be able to do that, the handler is
-// split in two parts: `default_handler_entry_point` and `default_handler`.
+// split in two parts: `_default_exception_handler` and `deh`.
 //
-// NOTE Do NOT modify this function.
+// NOTE Do NOT modify this function. You are free to modify the `deh` function
+// below though.
 #[doc(hidden)]
-#[export_name = "_default_exception_handler"]
 #[naked]
-pub unsafe extern "C" fn default_handler_entry_point() {
+#[no_mangle]
+pub unsafe extern "C" fn _default_exception_handler() {
     use core::intrinsics;
 
     // NOTE need asm!, #[naked] and unreachable() to avoid modifying the stack
     // pointer (MSP) so it points to the previous stack frame
     asm!("mrs r0, MSP
           ldr r1, [r0, #20]
-          b _default_exception_handler_impl" :::: "volatile");
+          b $0" :: "i"(deh as extern "C" fn(&StackFrame) -> !) :: "volatile");
 
     intrinsics::unreachable();
 }
 
 // Default exception handler that has access to previous stack frame `_sf`
-#[doc(hidden)]
-#[export_name = "_default_exception_handler_impl"]
-pub unsafe extern "C" fn default_handler(_sf: &StackFrame) -> ! {
-    bkpt!();
+extern "C" fn deh(_sf: &StackFrame) -> ! {
+    unsafe {
+        bkpt!();
+    }
 
     loop {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,14 @@
 //! A crate to hack the $DEVELOPMENT_BOARD!
 
 #![feature(asm)]
+#![feature(compiler_builtins_lib)]
 #![feature(core_intrinsics)]
 #![feature(lang_items)]
 #![feature(macro_reexport)]
 #![feature(naked_functions)]
 #![no_std]
 
-extern crate compiler_builtins_snapshot;
+extern crate compiler_builtins;
 #[macro_reexport(bkpt)]
 #[macro_use]
 extern crate cortex_m;


### PR DESCRIPTION
- hide the default_exception_handler symbol
- use git version of the compiler-builtins crate