### PR TITLE
make the hprint macros available even when semihosting is disabled

### DIFF
--- a/examples/semihosting.rs
+++ b/examples/semihosting.rs
@@ -1,19 +1,12 @@
 #![no_main]
 #![no_std]
 
-#[cfg_attr(feature = "semihosting", macro_use)]
+#[macro_use]
 extern crate board;
 
 #[no_mangle]
 pub fn main() -> ! {
-    match () {
-        #[cfg(feature = "semihosting")]
-        () => {
-            hprintln!("Hello, world!")
-        }
-        #[cfg(not(feature = "semihosting"))]
-        () => {}
-    }
+    hprintln!("Hello, world!");
 
     loop {}
 }

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -27,15 +27,7 @@ pub unsafe extern "C" fn _default_exception_handler() {
 
 // Default exception handler that has access to previous stack frame `_sf`
 extern "C" fn deh(_sf: &StackFrame) -> ! {
-    match () {
-        #[cfg(feature = "semihosting")]
-        () => {
-            hprintln!("EXCEPTION {:?} @ PC=0x{:08x}",
-                      Exception::current(), _sf.pc);
-        }
-        #[cfg(not(feature = "semihosting"))]
-        () => {}
-    }
+    hprintln!("EXCEPTION {:?} @ PC=0x{:08x}", Exception::current(), _sf.pc);
 
     unsafe {
         bkpt!();

--- a/src/lang_items.rs
+++ b/src/lang_items.rs
@@ -5,16 +5,16 @@ unsafe extern "C" fn panic_fmt(_args: Arguments,
                                _file: &'static str,
                                _line: u32)
                                -> ! {
+    hprint!("panicked at '");
     match () {
         #[cfg(feature = "semihosting")]
         () => {
-            hprint!("panicked at '");
             ::cortex_m_semihosting::io::_write_fmt(_args);
-            hprintln!("', {}:{}", _file, _line);
         }
         #[cfg(not(feature = "semihosting"))]
         () => {}
     }
+    hprintln!("', {}:{}", _file, _line);
 
     bkpt!();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ extern crate compiler_builtins;
 extern crate cortex_m;
 extern crate r0;
 
+#[macro_use]
+mod macros;
 mod lang_items;
 
 pub mod exception;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,11 @@
+#[cfg(not(feature = "semihosting"))]
+#[macro_export]
+macro_rules! hprint {
+    ($($arg:tt)*) => ();
+}
+
+#[cfg(not(feature = "semihosting"))]
+#[macro_export]
+macro_rules! hprintln {
+    ($($arg:tt)*) => ();
+}


### PR DESCRIPTION
in that case these macros expand to nothing