### PR TITLE
.init_array support and opt-in heap allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ cortex-m = "0.1.6"
 # r0 = "0.2.0"
 r0 = { git = "https://github.com/japaric/r0", branch = "init" }
 
+[dependencies.alloc-cortex-m]
+optional = true
+version = "0.2.1"
+
 [dependencies.cortex-m-semihosting]
 optional = true
 version = "0.1.2"
@@ -18,6 +22,7 @@ features = ["mem"]
 git = "https://github.com/rust-lang-nursery/compiler-builtins"
 
 [features]
+alloc = ["alloc-cortex-m"]
 semihosting = ["cortex-m-semihosting"]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ version = "0.1.0"
 
 [dependencies]
 cortex-m = "0.1.6"
-r0 = "0.2.0"
+# r0 = "0.2.0"
+r0 = { git = "https://github.com/japaric/r0", branch = "init" }
 
 [dependencies.cortex-m-semihosting]
 optional = true

--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,0 +1,1 @@
+[dependencies.collections]

--- a/examples/alloc.rs
+++ b/examples/alloc.rs
@@ -1,0 +1,23 @@
+#![feature(collections)]
+#![no_std]
+
+#[macro_use]
+extern crate {{name}};
+#[macro_use]
+extern crate collections;
+
+use {{name}}::exceptions::{self, Exceptions};
+use {{name}}::interrupts::{self, Interrupts};
+
+fn main() {
+    let xs = vec![0, 1, 2, 3];
+    hprintln!("{:?}", xs);
+}
+
+#[no_mangle]
+pub static _EXCEPTIONS: Exceptions =
+    Exceptions { ..exceptions::DEFAULT_HANDLERS };
+
+#[no_mangle]
+pub static _INTERRUPTS: Interrupts =
+    Interrupts { ..interrupts::DEFAULT_HANDLERS };

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -1,0 +1,27 @@
+#![no_std]
+
+#[macro_use]
+extern crate {{name}};
+
+use {{name}}::exceptions::{self, Exceptions};
+use {{name}}::interrupts::{self, Interrupts};
+
+pre_init_array!(before_before_main, {
+    hprintln!("Hello, world!")
+});
+
+init_array!(before_main, {
+    panic!("You've met with a terrible fate, haven't you?")
+});
+
+fn main() {
+    unreachable!()
+}
+
+#[no_mangle]
+pub static _EXCEPTIONS: Exceptions =
+    Exceptions { ..exceptions::DEFAULT_HANDLERS };
+
+#[no_mangle]
+pub static _INTERRUPTS: Interrupts =
+    Interrupts { ..interrupts::DEFAULT_HANDLERS };

--- a/memory.x
+++ b/memory.x
@@ -25,7 +25,14 @@ SECTIONS
     *(.text.start);
 
     *(.text.*);
+
     *(.rodata.*);
+    __pre_init_array_start = ALIGN(4);
+    KEEP(*(.pre_init_array));
+    __pre_init_array_end = ALIGN(4);
+    __init_array_start = ALIGN(4);
+    KEEP(*(.init_array));
+    __init_array_end = ALIGN(4);
   } > FLASH
 
   .bss : ALIGN(4)

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -50,10 +50,18 @@ pub unsafe extern "C" fn reset_handler() -> ! {
         static mut _sdata: u32;
 
         static _sidata: u32;
+
+        static __pre_init_array_start: extern "C" fn();
+        static __pre_init_array_end: extern "C" fn();
+
+        static __init_array_start: extern "C" fn();
+        static __init_array_end: extern "C" fn();
     }
 
     ::r0::zero_bss(&mut _sbss, &mut _ebss);
     ::r0::init_data(&mut _sdata, &mut _edata, &_sidata);
+    ::r0::run_init_array(&__pre_init_array_start, &__pre_init_array_end);
+    ::r0::run_init_array(&__init_array_start, &__init_array_end);
 
     // NOTE `rustc` forces this signature on us. See `src/rt.rs`
     extern "C" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ extern crate compiler_builtins;
 #[macro_reexport(bkpt)]
 #[macro_use]
 extern crate cortex_m;
+#[macro_reexport(pre_init_array, init_array)]
 extern crate r0;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 #![feature(naked_functions)]
 #![no_std]
 
+#[cfg(feature = "alloc")]
+extern crate alloc_cortex_m;
 #[cfg(feature = "semihosting")]
 #[macro_reexport(hprint, hprintln)]
 #[macro_use]
@@ -22,6 +24,7 @@ extern crate compiler_builtins;
 #[macro_use]
 extern crate cortex_m;
 #[macro_reexport(pre_init_array, init_array)]
+#[cfg_attr(feature = "alloc", macro_use)]
 extern crate r0;
 
 #[macro_use]
@@ -31,3 +34,13 @@ mod lang_items;
 
 pub mod exceptions;
 pub mod interrupts;
+
+#[cfg(feature = "alloc")]
+init_array!(alloc, {
+    extern "C" {
+        static mut _edata: usize;
+    }
+
+    // 1KiB heap
+    alloc_cortex_m::init(&mut _edata, (&mut _edata as *mut _).offset(256));
+});


### PR DESCRIPTION
With .init_array support, external crates (dependencies) can run code before
`main` is executed.

Usage looks like this:

``` rust
extern crate alloc_cortex_m;
#[macro_use]  // for `init_array!`
extern crate r0;

init_array!(alloc, {
    alloc_cortex_m::init(..);
});
```

However, the implementation is not reliable because there's no mechanism to
force `rustc` to emit symbols when they are apparently not used. Something like
GCC's `__attribute(used)__` would fix this. See rust-lang/rfcs#1002 and
rust-lang/rfcs#1459 for previous request of this feature.