### PR TITLE
Explicitly keep .text.start

### DIFF
--- a/memory.x
+++ b/memory.x
@@ -21,6 +21,7 @@ SECTIONS
     __interrupts = .;
 
     /* Entry point: the reset handler */
+    KEEP(*(.text.start));
     __reset = .;
     *(.text.start);
 


### PR DESCRIPTION
In my environments I was unable to prevent the linker from stripping out the `start` symbol at link time. By adding a KEEP directive, I was able to preserve it. This should not affect platforms that currently okay, and may help others.

For reference, I was using a Cortex-M3, with `xargo build --example app --target thumbv7m-none-eabi`. My linkers were the following (I tried on two platforms):

```
# On Debian Jessie
~ arm-none-eabi-ld --version
GNU ld (2.25-5+5+b1) 2.25

# On arch linux, using armgcc 4.9 2015q3
~ arm-none-eabi-ld --version
GNU ld (GNU Tools for ARM Embedded Processors) 2.24.0.20150921
```